### PR TITLE
Metabase Cloud SaaS Mode

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -7,31 +7,23 @@ contact-info:
   address: golubov.ax@yandex.ru
 driver:
   name: duckdb
-  display-name: DuckDB
+  display-name: MotherDuck
   lazy-load: true
   parent: sql-jdbc
   connection-properties:
     - name: database_file
-      display-name: Database file
-      placeholder: /home/to/the.duckdb (or ':memory:' for 'in memory' mode)
-      required: false
-    - name: read_only
-      display-name: Establish a read-only connection
-      default: false
-      type: boolean
+      display-name: MotherDuck database path
+      placeholder: "md:my_db"
+      required: true
     - name: old_implicit_casting
       display-name: Use DuckDB old_implicit_casting option
       default: true
-      type: boolean
-    - name: allow_unsigned_extensions
-      display-name: Allow loading unsigned extensions
-      default: false
       type: boolean
     - name: motherduck_token
       display-name: Motherduck Token
       type: secret
       secret-kind: password
-      required: false
+      required: true
 
 init:
   - step: load-namespace

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,10 +1,10 @@
 info:
   name: Metabase DuckDB Driver
-  version: 1.0.0-SNAPSHOT-0.1.13
+  version: 1.2.0
   description: Allows Metabase to connect to DuckDB databases.
 contact-info:
-  name: Alexander Golubov
-  address: golubov.ax@yandex.ru
+  name: MotherDuck Support
+  address: support@motherduck.com
 driver:
   name: duckdb
   display-name: MotherDuck
@@ -19,16 +19,6 @@ driver:
       display-name: Use DuckDB old_implicit_casting option
       default: true
       type: boolean
-    - name: allow_unsigned_extensions
-      display-name: Allow loading unsigned extensions
-      default: false
-      type: boolean
-    - name: memory_limit
-      display-name: Limit on the amount of memory that DuckDB can use (e.g., 1GB), defaults to 80% of RAM
-      required: false
-    - name: azure_transport_option_type
-      display-name: Azure transport option type
-      required: false
     - name: motherduck_token
       display-name: Motherduck Token
       type: secret

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -24,32 +24,31 @@
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
-  [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token], :as details}]
+  [{:keys [database_file, old_implicit_casting, motherduck_token], :as details}]
+  (when (not (seq (re-find #"^md:" database_file))) 
+    (throw (ex-info "Metabase Cloud requires MotherDuck connection string, local duckdb file or in-memory connection not supported. " {:database_file database_file}))) 
   (-> details 
       (merge
        {:classname         "org.duckdb.DuckDBDriver"
         :subprotocol       "duckdb"
         :subname           (or database_file "")
-        "duckdb.read_only" (str read_only) 
-        "custom_user_agent" (str "metabase" (if premium-features/is-hosted? " metabase-cloud" ""))
+        "custom_user_agent" (str "metabase" (if (premium-features/is-hosted?) " metabase-cloud" ""))
         "temp_directory"   (str database_file ".tmp")
         "jdbc_stream_results" "true"}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
-       (when allow_unsigned_extensions
-        {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
-       (when (seq (re-find #"^md:" database_file)) 
-         {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
+       {"motherduck_attach_mode"  "single"   ;; when connecting to MotherDuck, explicitly connect to a single database
+        "motherduck_saas_mode"    "true"}    ;; saas mode is required to limit what the DuckDB instance can do
        (when (seq motherduck_token)     ;; Only configure the option if token is provided
          {"motherduck_token" motherduck_token}))
-      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token) 
+      (dissoc :database_file :port :engine :old_implicit_casting :motherduck_token) 
       sql-jdbc.common/handle-additional-options))
 
 (defn- remove-keys-with-prefix [details prefix]
   (apply dissoc details (filter #(str/starts-with? (name %) prefix) (keys details))))
 
 (defmethod sql-jdbc.conn/connection-details->spec :duckdb
-  [_ details-map]
+  [_ details-map] 
   (-> details-map 
       (merge {:motherduck_token (or (-> (secret/db-details-prop->secret-map details-map "motherduck_token") 
                                         secret/value->string) 

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -67,7 +67,7 @@
         "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
         "temp_directory"   (str database_file ".tmp")
         "jdbc_stream_results" "true"
-        "saas_mode" "true"}
+        "motherduck_saas_mode" "true"}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
        (when (seq (re-find #"^md:" database_file)) 

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -63,24 +63,18 @@
       (merge
        {:classname         "org.duckdb.DuckDBDriver"
         :subprotocol       "duckdb"
-        :subname           (or database_file "")
-        "duckdb.read_only" (str read_only) 
+        :subname           (or database_file "") 
         "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
         "temp_directory"   (str database_file ".tmp")
-        "jdbc_stream_results" "true"}
+        "jdbc_stream_results" "true"
+        "saas_mode" "true"}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
-       (when memory_limit
-         {"memory_limit" (str memory_limit)})
-       (when azure_transport_option_type
-         {"azure_transport_option_type" (str azure_transport_option_type)})
-       (when allow_unsigned_extensions
-         {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
        (when (seq (re-find #"^md:" database_file)) 
          {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
        (when (seq motherduck_token)     ;; Only configure the option if token is provided
          {"motherduck_token" motherduck_token}))
-      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type) 
+      (dissoc :database_file :read_only :port :engine :old_implicit_casting :motherduck_token) 
       sql-jdbc.common/handle-additional-options))
 
 (defn- remove-keys-with-prefix [details prefix]

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -67,7 +67,8 @@
         "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
         "temp_directory"   (str database_file ".tmp")
         "jdbc_stream_results" "true"
-        "motherduck_saas_mode" "true"}
+        "motherduck_saas_mode" "true"
+        "memory_limit" "4GB"}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
        (when (seq (re-find #"^md:" database_file)) 

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -25,12 +25,10 @@
 (defmethod tx/supports-time-type? :duckdb [_driver] false)
 
 (defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}] 
-  {:read_only       false
-   :old_implicit_casting   true
+  {:old_implicit_casting   true
    "temp_directory"        (format "%s.ddb.tmp" database-name)
    :database_file (format "%s.ddb" database-name)
-   "custom_user_agent"     "metabase_test"
-   :allow_unsigned_extensions  false
+   "custom_user_agent"     "metabase_test" 
    :subname                (format "%s.ddb" database-name)})
 
 (doseq [[base-type db-type] {:type/BigInteger     "BIGINT"


### PR DESCRIPTION
In metabase cloud:
- Use saas_mode so computation always happens on MotherDuck instead of locally. this also ensures additional security flag is always on.
- Change the display name to MotherDuck since it's not possible to connect to "local" duckdbs since that uses the Metabase cloud computation. 
- As an additional safeguard, limit memory to 4GB. 


We'll keep 2 branches for now (main and metabase-cloud) since they have different configurations and there's no way to conditionally hide specific options in code.  