### PR TITLE
build metabase driver for Alpine

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
@@ -1,0 +1,134 @@
+name: Build DuckDB JDBC Musl and Metabase Driver
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+
+jobs:
+  java-linux-amd64-musl:
+    name: Java Musllinux (amd64)
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest 
+    env:
+      GEN: ninja
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      DUCKDB_PLATFORM: linux_amd64_musl
+    steps:
+      - name: Prepare Alpine Container
+        shell: sh
+        run: |
+          # Update package lists and install essential build tools
+          apk update
+          apk add --no-cache bash boost-dev build-base cmake gcc g++ git libstdc++ make maven ninja openjdk17 openjdk17-jdk pkgconfig 
+          
+          rm -rf /var/cache/apk/*
+
+          # Set Java environment variables
+          echo "JAVA_HOME=/usr/lib/jvm/java-17-openjdk" >> $GITHUB_ENV
+          echo "/usr/lib/jvm/java-17-openjdk/bin:${PATH}" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          submodules: recursive
+
+      - name: Build
+        shell: bash
+        working-directory: duckdb-java
+        run: make release
+
+      - name: Java Tests
+        shell: bash
+        if: ${{ inputs.skip_tests != 'true' }}
+        working-directory: duckdb-java
+        run: make test
+
+      - name: Get Version
+        id: get_version
+        shell: bash
+        working-directory: duckdb-java
+        run: |
+          VERSION=v1.2.0
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: java-linux-amd64-musl
+          path: |
+            duckdb-java/build/release/duckdb_jdbc.jar
+
+  build-metabase-driver:
+    name: Build Metabase Driver
+    needs: java-linux-amd64-musl
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Clone Metabase repository
+      uses: actions/checkout@v4
+      with:
+        repository: metabase/metabase
+        path: metabase
+        
+    - name: Checkout driver code
+      uses: actions/checkout@v4
+      with:
+        path: metabase/modules/drivers/duckdb
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: '3.9.6'
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+        
+    - name: Install Yarn 1.x
+      run: |
+        npm install -g yarn@1
+        yarn --version
+        
+    - name: Set up Clojure
+      uses: DeLaGuardo/setup-clojure@12.3
+      with:
+        cli: latest
+
+    - name: Download JDBC Driver
+      uses: actions/download-artifact@v4
+      with:
+        name: java-linux-amd64-musl
+        path: ./jdbc-driver
+
+    - name: Install DuckDB JDBC Driver (Musllinux)
+      run: |
+        VERSION=v1.2.0
+        mvn install:install-file \
+          -Dfile=./jdbc-driver/duckdb_jdbc.jar \
+          -DgroupId=org.duckdb \
+          -DartifactId=duckdb_jdbc \
+          -Dversion=$VERSION \
+          -Dpackaging=jar
+        
+    - name: Build driver
+      working-directory: ./metabase
+      run: |
+        git apply ./modules/drivers/duckdb/ci/metabase_drivers_deps.patch
+        chmod +x ./bin/build-driver.sh
+        ./bin/build-driver.sh duckdb
+        
+    - name: Upload driver artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: metabase-duckdb-driver-for-alpine
+        path: metabase/resources/modules/duckdb.metabase-driver.jar
+        if-no-files-found: error

--- a/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
@@ -46,14 +46,6 @@ jobs:
         working-directory: duckdb-java
         run: make test
 
-      - name: Get Version
-        id: get_version
-        shell: bash
-        working-directory: duckdb-java
-        run: |
-          VERSION=v1.2.0
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - uses: actions/upload-artifact@v4
         with:
           name: java-linux-amd64-musl
@@ -111,7 +103,7 @@ jobs:
 
     - name: Install DuckDB JDBC Driver (Musllinux)
       run: |
-        VERSION=v1.2.0
+        VERSION=1.2.0
         mvn install:install-file \
           -Dfile=./jdbc-driver/duckdb_jdbc.jar \
           -DgroupId=org.duckdb \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "duckdb-java"]
 	path = duckdb-java
-	url = https://github.com/hrl20/duckdb-java.git
+	url = https://github.com/motherduckdb/duckdb-java.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "duckdb-java"]
+	path = duckdb-java
+	url = https://github.com/hrl20/duckdb-java.git

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.1.3"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.2.0"}}}


### PR DESCRIPTION
build 2 versions of the driver.jar. 
- one current one as is.
- the other specifically for alpine.