### PR TITLE
 Add driver tests to workflow, update test extensions, and some driver fixes

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -23,11 +23,11 @@ jobs:
       with:
         path: metabase/modules/drivers/duckdb
         
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '21'
         
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -55,6 +55,7 @@ jobs:
       working-directory: ./metabase
       run: |
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
+        MB_EDITION=ee yarn build-static-viz
         DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
         
     - name: Upload driver artifact

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -51,6 +51,12 @@ jobs:
         chmod +x ./bin/build-driver.sh
         ./bin/build-driver.sh duckdb
         
+    - name: Run integration tests
+      working-directory: ./metabase
+      run: |
+        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
+        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+        
     - name: Upload driver artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
@@ -69,11 +69,11 @@ jobs:
       with:
         path: metabase/modules/drivers/duckdb
 
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '21'
 
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5

--- a/ci/metabase_drivers_deps.patch
+++ b/ci/metabase_drivers_deps.patch
@@ -1,11 +1,11 @@
 diff --git a/modules/drivers/deps.edn b/modules/drivers/deps.edn
-index 0868e24de0..8d6c76a8ef 100644
+index 98f65a210d..e0c8da9d68 100644
 --- a/modules/drivers/deps.edn
 +++ b/modules/drivers/deps.edn
-@@ -21,4 +21,6 @@
-   metabase/sparksql           {:local/root "sparksql"}
+@@ -23,4 +23,6 @@
    metabase/sqlite             {:local/root "sqlite"}
    metabase/sqlserver          {:local/root "sqlserver"}
+   metabase/starburst          {:local/root "starburst"}
 -  metabase/vertica            {:local/root "vertica"}}}
 +  metabase/vertica            {:local/root "vertica"}
 +  metabase/duckdb             {:local/root "duckdb"}

--- a/ci/metabase_test_deps.patch
+++ b/ci/metabase_test_deps.patch
@@ -1,0 +1,14 @@
+diff --git a/deps.edn b/deps.edn
+index 764376f2bf..93c5b496c6 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -432,7 +432,8 @@
+     "modules/drivers/sparksql/test"
+     "modules/drivers/sqlite/test"
+     "modules/drivers/sqlserver/test"
+-    "modules/drivers/vertica/test"]}
++    "modules/drivers/vertica/test"
++    "modules/drivers/duckdb/test"]}
+ 
+ ;;; Linters
+ 

--- a/ci/metabase_test_deps.patch
+++ b/ci/metabase_test_deps.patch
@@ -1,15 +1,15 @@
 diff --git a/deps.edn b/deps.edn
-index 96a21dc7a2..5d182d568b 100644
+index 67e3128c77..c656572f23 100644
 --- a/deps.edn
 +++ b/deps.edn
 @@ -430,7 +430,9 @@
      "modules/drivers/sqlite/test"
-     "modules/drivers/sqlserver/test" 
+     "modules/drivers/sqlserver/test"
      "modules/drivers/starburst/test"
 -    "modules/drivers/vertica/test"]}
 +    "modules/drivers/vertica/test"
 +    "modules/drivers/duckdb/test"
 +    ]}
  
- 
  ;;; Linters
+ 

--- a/ci/metabase_test_deps.patch
+++ b/ci/metabase_test_deps.patch
@@ -1,14 +1,15 @@
 diff --git a/deps.edn b/deps.edn
-index 764376f2bf..93c5b496c6 100644
+index 96a21dc7a2..5d182d568b 100644
 --- a/deps.edn
 +++ b/deps.edn
-@@ -432,7 +432,8 @@
-     "modules/drivers/sparksql/test"
+@@ -430,7 +430,9 @@
      "modules/drivers/sqlite/test"
-     "modules/drivers/sqlserver/test"
+     "modules/drivers/sqlserver/test" 
+     "modules/drivers/starburst/test"
 -    "modules/drivers/vertica/test"]}
 +    "modules/drivers/vertica/test"
-+    "modules/drivers/duckdb/test"]}
++    "modules/drivers/duckdb/test"
++    ]}
+ 
  
  ;;; Linters
- 

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.2.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.2.1"}}}

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -10,9 +10,11 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.util.honey-sql-2 :as h2x])
+   [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.log :as log])
   (:import
    (java.sql
+    Connection
     PreparedStatement
     ResultSet
     ResultSetMetaData
@@ -26,6 +28,11 @@
 
 (driver/register! :duckdb, :parent :sql-jdbc)
 
+(doseq [[feature supported?] {:metadata/key-constraints      false
+                              :foreign-keys                  false
+                              :upload-with-auto-pk           false}]
+  (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
+
 (def premium-features-namespace
   (try
     (require '[metabase.premium-features.core :as premium-features])    ;; For Metabase 0.52 or after 
@@ -36,49 +43,48 @@
         'metabase.public-settings.premium-features
         (catch Exception e
           (throw (ex-info "Could not load either premium features namespace"
-                         {:error e})))))))
+                          {:error e})))))))
 
-
-(defn is-hosted?  []  
+(defn is-hosted?  []
   (let [premium-feature-ns (find-ns premium-features-namespace)]
-     ((ns-resolve premium-feature-ns 'is-hosted?))))
+    ((ns-resolve premium-feature-ns 'is-hosted?))))
 
 (defn get-motherduck-token [details-map]
   (try
      ;; For Metabase 0.52 or after 
-     ((requiring-resolve 'metabase.models.secret/value-as-string) :duckdb details-map "motherduck_token")
-     (catch Exception _
+    ((requiring-resolve 'metabase.models.secret/value-as-string) :duckdb details-map "motherduck_token")
+    (catch Exception _
        ;; For Metabase < 0.52
-       (or (-> ((requiring-resolve 'metabase.models.secret/db-details-prop->secret-map) details-map "motherduck_token")
-                   ((requiring-resolve 'metabase.models.secret/value->string)))
-           ((requiring-resolve 'metabase.models.secret/get-secret-string) details-map "motherduck_token")))))
-
+      (or (-> ((requiring-resolve 'metabase.models.secret/db-details-prop->secret-map) details-map "motherduck_token")
+              ((requiring-resolve 'metabase.models.secret/value->string)))
+          ((requiring-resolve 'metabase.models.secret/get-secret-string) details-map "motherduck_token")))))
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
   [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token, memory_limit, azure_transport_option_type], :as details}]
-  (-> details 
+  (-> details
       (merge
        {:classname         "org.duckdb.DuckDBDriver"
         :subprotocol       "duckdb"
         :subname           (or database_file "")
-        "duckdb.read_only" (str read_only) 
+        "duckdb.read_only" (str read_only)
         "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
         "temp_directory"   (str database_file ".tmp")
-        "jdbc_stream_results" "true"}
+        "jdbc_stream_results" "true"
+        :TimeZone (or (driver/report-timezone) "UTC")}
        (when old_implicit_casting
          {"old_implicit_casting" (str old_implicit_casting)})
        (when memory_limit
          {"memory_limit" (str memory_limit)})
-        (when azure_transport_option_type
-          {"azure_transport_option_type" (str azure_transport_option_type)})
+       (when azure_transport_option_type
+         {"azure_transport_option_type" (str azure_transport_option_type)})
        (when allow_unsigned_extensions
-        {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
-       (when (seq (re-find #"^md:" database_file)) 
+         {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
+       (when (seq (re-find #"^md:" database_file))
          {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
        (when (seq motherduck_token)     ;; Only configure the option if token is provided
          {"motherduck_token" motherduck_token}))
-      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type) 
+      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type)
       sql-jdbc.common/handle-additional-options))
 
 (defn- remove-keys-with-prefix [details prefix]
@@ -86,16 +92,36 @@
 
 (defmethod sql-jdbc.conn/connection-details->spec :duckdb
   [_ details-map]
-  (-> details-map 
+  (-> details-map
       (merge {:motherduck_token (get-motherduck-token details-map)})
       (remove-keys-with-prefix "motherduck_token-")
       jdbc-spec))
 
+(defmethod sql-jdbc.execute/do-with-connection-with-options :duckdb
+  [driver db-or-id-or-spec {:keys [^String session-timezone report-timezone] :as options} f]
+  ;; First use the parent implementation to get the connection with standard options
+  (sql-jdbc.execute/do-with-resolved-connection
+   driver
+   db-or-id-or-spec
+   options
+   (fn [^Connection conn]
+     ;; Additionally set timezone if provided and we're not in a recursive connection
+     (when (and (or report-timezone session-timezone) (not (sql-jdbc.execute/recursive-connection?)))
+       (let [timezone-to-use (or report-timezone session-timezone)]
+         (try
+           (with-open [stmt (.createStatement conn)]
+             (log/infof (format "timezone exists!!! %s" timezone-to-use))
+             (.execute stmt (format "SET TimeZone='%s';" timezone-to-use)))
+           (catch Throwable e
+             (log/debugf e "Error setting timezone '%s' for DuckDB database" timezone-to-use)))))
+     ;; Call the function with the configured connection
+     (f conn))))
+
 (defmethod sql-jdbc.execute/set-timezone-sql :duckdb [_]
   "SET GLOBAL TimeZone=%s;")
 
-(def ^:private database-type->base-type 
-  (sql-jdbc.sync/pattern-based-database-type->base-type 
+(def ^:private database-type->base-type
+  (sql-jdbc.sync/pattern-based-database-type->base-type
    [[#"BOOLEAN"                  :type/Boolean]
     [#"BOOL"                     :type/Boolean]
     [#"LOGICAL"                  :type/Boolean]
@@ -143,8 +169,7 @@
     [#"TIMESTAMP"                :type/DateTime]
     [#"DATE"                     :type/Date]
     [#"TIME"                     :type/Time]
-    [#"GEOMETRY"                 :type/*]
-    ]))
+    [#"GEOMETRY"                 :type/*]]))
 
 (defmethod sql-jdbc.sync/database-type->base-type :duckdb
   [_ field-type]
@@ -170,7 +195,6 @@
   [_ ^PreparedStatement prepared-statement i t]
   (.setObject prepared-statement i t))
 
-
 ;; .getObject of DuckDB (v0.4.0) does't handle the java.time.LocalDate but sql.Date only,
 ;; so get the sql.Date from DuckDB and convert it to java.time.LocalDate
 (defmethod sql-jdbc.execute/read-column-thunk [:duckdb Types/DATE]
@@ -190,10 +214,10 @@
 ;; override the sql-jdbc.execute/read-column-thunk for TIMESTAMP based on
 ;; DuckDB JDBC implementation.
 (defmethod sql-jdbc.execute/read-column-thunk [:duckdb Types/TIMESTAMP]
-   [_ ^ResultSet rs _ ^Integer i]
-    (fn []
-     (when-let [t (.getTimestamp rs i)]
-       (t/local-date-time t))))
+  [_ ^ResultSet rs _ ^Integer i]
+  (fn []
+    (when-let [t (.getTimestamp rs i)]
+      (t/local-date-time t))))
 
 ;; date processing for aggregation
 (defmethod driver/db-start-of-week :duckdb [_] :monday)
@@ -233,7 +257,7 @@
 
 (defmethod sql.qp/->honeysql [:duckdb :regex-match-first]
   [driver [_ arg pattern]]
-  [:regexp_extract (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern) 0])
+  [:regexp_extract (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)])
 
 ;; empty result set for queries without result (like insert...)
 (defn- empty-rs []
@@ -267,16 +291,16 @@
 
 (defmethod driver/describe-database :duckdb
   [driver database]
-  (let 
+  (let
    [database_file (get (get database :details) :database_file)
     get_tables_query (str "select * from information_schema.tables "
                                ;; Additionally filter by db_name if connecting to MotherDuck, since
                                ;; multiple databases can be attached and information about the
                                ;; non-target database will be present in information_schema. 
-                                  (if (is_motherduck database_file)
-                                    (let [db_name (motherduck_db_name database_file)]
-                                      (format "where table_catalog = '%s' " db_name))
-                                    ""))]
+                          (if (is_motherduck database_file)
+                            (let [db_name (motherduck_db_name database_file)]
+                              (format "where table_catalog = '%s' " db_name))
+                            ""))]
     {:tables
      (sql-jdbc.execute/do-with-connection-with-options
       driver database nil
@@ -287,22 +311,20 @@
                            [get_tables_query])]
            {:name table_name :schema table_schema}))))}))
 
-
-
 (defmethod driver/describe-table :duckdb
   [driver database {table_name :name, schema :schema}]
   (let [database_file (get (get database :details) :database_file)
-               get_columns_query (str 
-                                  (format 
-                                   "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'" 
-                                   table_name schema) 
+        get_columns_query (str
+                           (format
+                            "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'"
+                            table_name schema)
                                   ;; Additionally filter by db_name if connecting to MotherDuck, since
                                   ;; multiple databases can be attached and information about the
                                   ;; non-target database will be present in information_schema. 
-                                  (if (is_motherduck database_file)
-                                    (let [db_name (motherduck_db_name database_file)]
-                                      (format "and table_catalog = '%s' " db_name))
-                                    ""))]
+                           (if (is_motherduck database_file)
+                             (let [db_name (motherduck_db_name database_file)]
+                               (format "and table_catalog = '%s' " db_name))
+                             ""))]
     {:name   table_name
      :schema schema
      :fields

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -1,36 +1,33 @@
 (ns metabase.test.data.duckdb
   (:require
-   [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]
    [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
-   [metabase.test.data.sql-jdbc.execute :as execute]
    [metabase.test.data.sql-jdbc.load-data :as load-data]
-   [metabase.test.data.sql.ddl :as ddl]
-   [metabase.util :as u]
-   [metabase.util.log :as log]))
+
+   [metabase.test.data.sql.ddl :as ddl]))
 
 (set! *warn-on-reflection* true)
 
 (sql-jdbc.tx/add-test-extensions! :duckdb)
 
-(doseq [[feature supported?] {:foreign-keys  (not config/is-test?) 
-                              :upload-with-auto-pk (not config/is-test?)}]
+(doseq [[feature supported?] {:foreign-keys  (not config/is-test?)
+                              :upload-with-auto-pk (not config/is-test?)
+                              :test/time-type false
+                              ::describe-table-test/describe-materialized-view-fields false}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
 
-(defmethod tx/supports-time-type? :duckdb [_driver] false)
-
-(defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}] 
-  {:read_only       false
-   :old_implicit_casting   true
+(defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}]
+  {:old_implicit_casting   true
    "temp_directory"        (format "%s.ddb.tmp" database-name)
    :database_file (format "%s.ddb" database-name)
    "custom_user_agent"     "metabase_test"
-   :allow_unsigned_extensions  false
    :subname                (format "%s.ddb" database-name)})
 
 (doseq [[base-type db-type] {:type/BigInteger     "BIGINT"
@@ -45,7 +42,6 @@
                              :type/Time           "TIME"
                              :type/UUID           "UUID"}]
   (defmethod sql.tx/field-base-type->sql-type [:duckdb base-type] [_ _] db-type))
-
 
 (defmethod sql.tx/pk-sql-type :duckdb [_] "INTEGER")
 
@@ -62,48 +58,29 @@
     (when (.exists wal-file)
       (.delete wal-file))))
 
-
 (defmethod sql.tx/add-fk-sql            :duckdb [& _] nil)
 
-(defmethod load-data/load-data! :duckdb [& args]
-  (apply load-data/load-data-maybe-add-ids-chunked! args))
-
-(defonce ^:private reference-load-durations
-  (delay (edn/read-string (slurp "test_resources/load-durations.edn"))))
-
+(defmethod load-data/row-xform :duckdb
+  [_driver _dbdef tabledef]
+  (load-data/maybe-add-ids-xform tabledef))
 
 (defmethod tx/sorts-nil-first? :duckdb
   [_driver _base-type]
   false)
 
-(defmethod tx/create-db! :duckdb
-  [driver {:keys [table-definitions] :as dbdef} & options] 
-  (try 
-    (doseq [statement (apply ddl/drop-db-ddl-statements driver dbdef options)]
-      (execute/execute-sql! driver :server dbdef statement))
-    (catch Throwable e
-      (log/infof "Error dropping DB: %s" (ex-message e))))
-  
-  (tx/destroy-db! driver dbdef)
-  ;; now execute statements to create the DB
-  (doseq [statement (ddl/create-db-ddl-statements driver dbdef)]
-    (execute/execute-sql! driver :server dbdef statement))
-  ;; next, get a set of statements for creating the tables
-  (let [statements (apply ddl/create-db-tables-ddl-statements driver dbdef options)]
-    ;; exec the combined statement. Notice we're now executing in the `:db` context e.g. executing them for a specific
-    ;; DB rather than on `:server` (no DB in particular)
-    (execute/execute-sql! driver :db dbdef (str/join ";\n" statements)))
-  ;; Now load the data for each Table
-  (doseq [tabledef table-definitions
-          :let     [reference-duration (or (some-> (get @reference-load-durations [(:database-name dbdef) (:table-name tabledef)])
-                                                   u/format-nanoseconds)
-                                           "NONE")]]
-    (u/profile (format "load-data for %s %s %s (reference H2 duration: %s)"
-                       (name driver) (:database-name dbdef) (:table-name tabledef) reference-duration)
-               (try
-                 (load-data/load-data! driver dbdef tabledef)
-                 (catch Throwable e
-                   (throw (ex-info (format "Error loading data: %s" (ex-message e))
-                                   {:driver driver, :tabledef (update tabledef :rows (fn [rows]
-                                                                                       (concat (take 10 rows) ['...])))}
-                                   e)))))))
+(defmethod tx/dataset-already-loaded? :duckdb
+  [driver dbdef]
+  ;; check and make sure the first table in the dbdef has been created.
+  (let [{:keys [table-name], :as _tabledef} (first (:table-definitions dbdef))]
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :db dbdef))
+     {:write? false}
+     (fn [^java.sql.Connection conn]
+       (with-open [rset (.getTables (.getMetaData conn)
+                                    #_catalog        nil
+                                    #_schema-pattern nil
+                                    #_table-pattern  table-name
+                                    #_types          (into-array String ["BASE TABLE"]))]
+         ;; if the ResultSet returns anything we know the table is already loaded.
+         (.next rset))))))

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -20,8 +20,13 @@
 (doseq [[feature supported?] {:foreign-keys  (not config/is-test?)
                               :upload-with-auto-pk (not config/is-test?)
                               :test/time-type false
-                              ::describe-table-test/describe-materialized-view-fields false}]
+                              ::describe-table-test/describe-materialized-view-fields false
+                              :test/cannot-destroy-db true}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
+
+(defmethod tx/bad-connection-details :duckdb
+  [_driver]
+  {:unknown_config "single"})
 
 (defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}]
   {:old_implicit_casting   true

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -17,10 +17,9 @@
 
 (sql-jdbc.tx/add-test-extensions! :duckdb)
 
-(doseq [[feature supported?] {:foreign-keys  (not config/is-test?)
-                              :upload-with-auto-pk (not config/is-test?)
+(doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
                               :test/time-type false
-                              ::describe-table-test/describe-materialized-view-fields false
+                              ::describe-table-test/describe-materialized-view-fields false  ;; duckdb has no materialized views
                               :test/cannot-destroy-db true}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
 


### PR DESCRIPTION
Most of the changes are to set up testing and addresstest failures:
* Have CI run the test. currently against local file duckdb. (to follow up with test set up against MotherDuck)
* address changes mentioned in to the test extension interface https://www.metabase.com/docs/latest/developers-guide/driver-changelog 

* also bump duckdb to 1.2.1.

there are ~3 tests that are currently failing, will follow up with Metabase team on ways to address them. 