### PR TITLE
add integration test with motherduck

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -60,6 +60,7 @@ jobs:
         
     - name: Run integration tests against MotherDuck
       working-directory: ./metabase
+      continue-on-error: true
       env:
           motherduck_token: ${{ secrets.motherduck_ci_user_token }}
       run: |
@@ -69,9 +70,9 @@ jobs:
        
     - name: Run integration tests against DuckDB local
       working-directory: ./metabase
+      continue-on-error: true
       run: |
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
         MB_EDITION=ee yarn build-static-viz
         DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
-
 

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -53,6 +53,8 @@ jobs:
         
     - name: Run integration tests
       working-directory: ./metabase
+      env:
+          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
       run: |
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
         MB_EDITION=ee yarn build-static-viz

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -57,12 +57,15 @@ jobs:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
-       
+        
     - name: Run integration tests
       working-directory: ./metabase
+      strategy:
+        matrix:
+          driver: [motherduck, duckdb]
       env:
-          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
+        motherduck_token: ${{ secrets.motherduck_ci_user_token }}
       run: |
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
         MB_EDITION=ee yarn build-static-viz
-        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+        DRIVERS=${{ matrix.driver }} clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -58,14 +58,20 @@ jobs:
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
         
-    - name: Run integration tests
+    - name: Run integration tests against MotherDuck
       working-directory: ./metabase
-      strategy:
-        matrix:
-          driver: [motherduck, duckdb]
       env:
-        motherduck_token: ${{ secrets.motherduck_ci_user_token }}
+          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
       run: |
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
         MB_EDITION=ee yarn build-static-viz
-        DRIVERS=${{ matrix.driver }} clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+        DRIVERS=motherduck clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+       
+    - name: Run integration tests against DuckDB local
+      working-directory: ./metabase
+      run: |
+        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
+        MB_EDITION=ee yarn build-static-viz
+        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+
+

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -72,7 +72,5 @@ jobs:
       working-directory: ./metabase
       continue-on-error: true
       run: |
-        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
-        MB_EDITION=ee yarn build-static-viz
         DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
 

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -95,7 +95,7 @@
          (when allow_unsigned_extensions
            {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
          (when (seq (re-find #"^md:" database_file))
-            ;; attach_mode option is not settable the user, it's always single mode when 
+            ;; attach_mode option is not settable by the user, it's always single mode when 
             ;; using motherduck, but in tests we need to be able to connect to motherduck in 
             ;; workspace mode, so it's handled here.
            {"motherduck_attach_mode"  (or attach_mode "single")})    ;; when connecting to MotherDuck, explicitly connect to a single database

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -102,7 +102,7 @@
         ;; remove fields from the metabase config that do not directly go into the jdbc spec
         (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions 
                 :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type 
-                :advanced-options :additional-options))))
+                :advanced-options :additional-options :attach_mode))))
 
 (defn- remove-keys-with-prefix [details prefix]
   (apply dissoc details (filter #(str/starts-with? (name %) prefix) (keys details))))

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -105,15 +105,9 @@
          (sql-jdbc.common/additional-options->map (:additional-options details) :url)
          (sql-jdbc.common/additional-options->map database_file_additional_options :url))
         ;; remove fields from the metabase config that do not directly go into the jdbc spec
-<<<<<<< HEAD
         (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions 
                 :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type 
                 :advanced-options :additional-options :attach_mode))))
-=======
-        (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions
-                :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type
-                :advanced-options :additional-options))))
->>>>>>> main
 
 (defn- remove-keys-with-prefix [details prefix]
   (apply dissoc details (filter #(str/starts-with? (name %) prefix) (keys details))))

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -73,7 +73,8 @@
 
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
-  [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token, memory_limit, azure_transport_option_type, attach_mode], :as details}] 
+  [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, 
+           motherduck_token, memory_limit, azure_transport_option_type, attach_mode], :as details}] 
   (let [[database_file_base database_file_additional_options] (database-file-path-split database_file)]
     (-> details 
         (merge
@@ -94,6 +95,9 @@
          (when allow_unsigned_extensions
            {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
          (when (seq (re-find #"^md:" database_file))
+            ;; attach_mode option is not settable the user, it's always single mode when 
+            ;; using motherduck, but in tests we need to be able to connect to motherduck in 
+            ;; workspace mode, so it's handled here.
            {"motherduck_attach_mode"  (or attach_mode "single")})    ;; when connecting to MotherDuck, explicitly connect to a single database
          (when (seq motherduck_token)     ;; Only configure the option if token is provided
            {"motherduck_token" motherduck_token})

--- a/src/metabase/driver/motherduck.clj
+++ b/src/metabase/driver/motherduck.clj
@@ -1,0 +1,6 @@
+(ns metabase.driver.motherduck 
+  (:require    
+   [metabase.driver :as driver]))
+
+
+(driver/register! :motherduck, :parent :duckdb)

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -1,17 +1,16 @@
 (ns metabase.test.data.duckdb
   (:require
-   [clojure.tools.logging :as log]
+   [clojure.java.io :as io]
    [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
    [metabase.test.data.interface :as tx]
-   [metabase.test.data.sql :as sql.tx :refer [qualify-and-quote]]
-   [metabase.test.data.sql-jdbc :as sql-jdbc.tx] 
-   [metabase.test.data.sql-jdbc.execute :as sql-jdbc.test-execute]
+   [metabase.test.data.sql :as sql.tx]
+   [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
    [metabase.test.data.sql-jdbc.load-data :as load-data]
-   [metabase.test.data.sql-jdbc.spec  :refer [dbdef->spec]]
+
    [metabase.test.data.sql.ddl :as ddl]))
 
 (set! *warn-on-reflection* true)
@@ -28,38 +27,12 @@
   [_driver]
   {:unknown_config "single"})
 
-(defmethod dbdef->spec :duckdb [driver context dbdef]
-  (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver context dbdef)))
-
-(defn- md-workspace-mode-spec 
-  []
-  (sql-jdbc.conn/connection-details->spec :duckdb {:old_implicit_casting   true
-                                                  "custom_user_agent"     "metabase_test"
-                                                  :database_file          "md:"
-                                                  :subname                "md:"
-                                                  :attach_mode            "workspace"}))
-
-(defmethod tx/create-db! :duckdb
-  [driver dbdef & options] 
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-    ;; `:db` context = use the specific database we created in [[create-db-execute-server-statements!]]
-   (md-workspace-mode-spec)
-   {:write? true}
-   (fn [^java.sql.Connection conn]
-     (try (.setAutoCommit conn true)
-          (catch Throwable _
-            (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
-     (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
-
-  (apply load-data/create-db! driver dbdef options))
-
-
-  (defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]} ] 
-    {:old_implicit_casting   true
-     "custom_user_agent"     "metabase_test"
-     :database_file         (format "md:%s" database-name)
-     :subname               (format "md:%s" database-name)})
+(defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}]
+  {:old_implicit_casting   true
+   "temp_directory"        (format "%s.ddb.tmp" database-name)
+   :database_file (format "%s.ddb" database-name)
+   "custom_user_agent"     "metabase_test"
+   :subname                (format "%s.ddb" database-name)})
 
 (doseq [[base-type db-type] {:type/BigInteger     "BIGINT"
                              :type/Boolean        "BOOL"
@@ -76,17 +49,18 @@
 
 (defmethod sql.tx/pk-sql-type :duckdb [_] "INTEGER")
 
-;; (defmethod sql.tx/drop-db-if-exists-sql    :duckdb [driver {:keys [database-name]}] (format "DROP DATABASE IF EXISTS %s CASCADE" (qualify-and-quote driver database-name)))
 (defmethod sql.tx/drop-db-if-exists-sql    :duckdb [& _] nil)
+(defmethod ddl/drop-db-ddl-statements   :duckdb [& _] nil)
+(defmethod sql.tx/create-db-sql         :duckdb [& _] nil)
 
-(defmethod ddl/drop-db-ddl-statements   :duckdb [driver {:keys [database-name]}] 
-  ["ATTACH ':memory:' AS memdb;"
-   "USE memdb;"
-   (format "DROP DATABASE %s CASCADE;" (qualify-and-quote driver database-name))])
-
-(defmethod sql.tx/create-db-sql :duckdb
-  [driver {:keys [database-name]}]
-  (format "CREATE DATABASE IF NOT EXISTS %s;" (qualify-and-quote driver database-name)))
+(defmethod tx/destroy-db! :duckdb
+  [_driver dbdef]
+  (let [file (io/file (str (tx/escaped-database-name dbdef) ".ddb"))
+        wal-file (io/file (str (tx/escaped-database-name dbdef) ".ddb.wal"))]
+    (when (.exists file)
+      (.delete file))
+    (when (.exists wal-file)
+      (.delete wal-file))))
 
 (defmethod sql.tx/add-fk-sql            :duckdb [& _] nil)
 
@@ -101,54 +75,16 @@
 (defmethod tx/dataset-already-loaded? :duckdb
   [driver dbdef]
   ;; check and make sure the first table in the dbdef has been created.
-  (let [{:keys [table-name database-name], :as _tabledef} (first (:table-definitions dbdef))]
-    (sql-jdbc.execute/do-with-connection-with-options
-     driver
-     (md-workspace-mode-spec)
-     {:write? true}
-     (fn [^java.sql.Connection conn]
-       (try (.setAutoCommit conn true)
-            (catch Throwable _
-              (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
-       (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
-    
+  (let [{:keys [table-name], :as _tabledef} (first (:table-definitions dbdef))]
     (sql-jdbc.execute/do-with-connection-with-options
      driver
      (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :db dbdef))
      {:write? false}
      (fn [^java.sql.Connection conn]
        (with-open [rset (.getTables (.getMetaData conn)
-                                    #_catalog        database-name
+                                    #_catalog        nil
                                     #_schema-pattern nil
                                     #_table-pattern  table-name
                                     #_types          (into-array String ["BASE TABLE"]))]
+         ;; if the ResultSet returns anything we know the table is already loaded.
          (.next rset))))))
-
-
-(defn- delete-old-databases!
-  "Remove all databases from motherduck account except for the default ones. Test runs can create databases that need to be cleaned up."
-  [^java.sql.Connection conn]
-  (let [drop-sql (fn [db-name] (format "DROP DATABASE IF EXISTS \"%s\" CASCADE;" db-name))]
-    (with-open [stmt (.createStatement conn)]
-      (with-open [rset (.executeQuery stmt "select database_name from duckdb_databases() where type = 'motherduck' and database_name not in ('my_db', 'sample_data'); ")]
-        (while (.next rset) 
-          (let [db-name (.getString rset "database_name")]
-            (with-open [inner-stmt (.createStatement conn)]
-              (.execute inner-stmt (drop-sql db-name)))))))))
-
-(defmethod tx/before-run :duckdb
-  [driver]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   (md-workspace-mode-spec)
-   {:write? true}
-   delete-old-databases!))
-
-
-(defmethod tx/after-run :duckdb
-  [driver]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   (md-workspace-mode-spec)
-   {:write? true}
-   delete-old-databases!))

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -90,15 +90,6 @@
   [driver {:keys [database-name]}]
   (format "CREATE DATABASE IF NOT EXISTS %s;" (qualify-and-quote driver database-name)))
 
-;; (defmethod tx/destroy-db! :duckdb
-;;   [_driver dbdef]
-;;   (let [file (io/file (str (tx/escaped-database-name dbdef) ".ddb"))
-;;         wal-file (io/file (str (tx/escaped-database-name dbdef) ".ddb.wal"))]
-;;     (when (.exists file)
-;;       (.delete file))
-;;     (when (.exists wal-file)
-;;       (.delete wal-file))))
-
 (defmethod sql.tx/add-fk-sql            :duckdb [& _] nil)
 
 (defmethod load-data/row-xform :duckdb

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -8,7 +8,6 @@
    [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx :refer [qualify-and-quote]]
-   [metabase.test.data.sql-jdbc :as sql-jdbc.tx] 
    [metabase.test.data.sql-jdbc.execute :as sql-jdbc.test-execute]
    [metabase.test.data.sql-jdbc.load-data :as load-data]
    [metabase.test.data.sql-jdbc.spec  :refer [dbdef->spec]]
@@ -16,8 +15,7 @@
 
 (set! *warn-on-reflection* true)
 
-
-(sql-jdbc.tx/add-test-extensions! :motherduck)
+;; (sql-jdbc.tx/add-test-extensions! :motherduck)
 
 (doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
                               :test/time-type false

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -73,10 +73,8 @@
 
 (defmethod sql.tx/pk-sql-type :motherduck [_] "INTEGER")
 
-(defmethod sql.tx/drop-db-if-exists-sql    :motherduck [& _] nil)
-
 (defmethod ddl/drop-db-ddl-statements   :motherduck [driver {:keys [database-name]}] 
-  ["ATTACH ':memory:' AS memdb;"
+  ["ATTACH IF NOT EXISTS ':memory:' AS memdb;"
    "USE memdb;"
    (format "DROP DATABASE %s CASCADE;" (qualify-and-quote driver database-name))])
 
@@ -103,9 +101,6 @@
      (md-workspace-mode-spec)
      {:write? true}
      (fn [^java.sql.Connection conn]
-       (try (.setAutoCommit conn true)
-            (catch Throwable _
-              (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
        (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
     
     (sql-jdbc.execute/do-with-connection-with-options

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -1,0 +1,155 @@
+(ns metabase.test.data.motherduck
+  (:require
+   [clojure.tools.logging :as log]
+   [metabase.config :as config]
+   [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
+   [metabase.test.data.interface :as tx]
+   [metabase.test.data.sql :as sql.tx :refer [qualify-and-quote]]
+   [metabase.test.data.sql-jdbc :as sql-jdbc.tx] 
+   [metabase.test.data.sql-jdbc.execute :as sql-jdbc.test-execute]
+   [metabase.test.data.sql-jdbc.load-data :as load-data]
+   [metabase.test.data.sql-jdbc.spec  :refer [dbdef->spec]]
+   [metabase.test.data.sql.ddl :as ddl]))
+
+(set! *warn-on-reflection* true)
+
+
+(sql-jdbc.tx/add-test-extensions! :motherduck)
+
+(doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
+                              :test/time-type false
+                              ::describe-table-test/describe-materialized-view-fields false  ;; motherduck has no materialized views
+                              :test/cannot-destroy-db true}]
+  (defmethod driver/database-supports? [:motherduck feature] [_driver _feature _db] supported?))
+
+(defmethod tx/bad-connection-details :motherduck
+  [_driver]
+  {:unknown_config "single"})
+
+(defmethod dbdef->spec :motherduck [driver context dbdef]
+  (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver context dbdef)))
+
+(defn- md-workspace-mode-spec 
+  []
+  (sql-jdbc.conn/connection-details->spec :motherduck {:old_implicit_casting   true
+                                                  "custom_user_agent"     "metabase_test"
+                                                  :database_file          "md:"
+                                                  :subname                "md:"
+                                                  :attach_mode            "workspace"}))
+
+(defmethod tx/create-db! :motherduck
+  [driver dbdef & options] 
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+    ;; `:db` context = use the specific database we created in [[create-db-execute-server-statements!]]
+   (md-workspace-mode-spec)
+   {:write? true}
+   (fn [^java.sql.Connection conn]
+     (try (.setAutoCommit conn true)
+          (catch Throwable _
+            (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
+     (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
+
+  (apply load-data/create-db! driver dbdef options))
+
+
+  (defmethod tx/dbdef->connection-details :motherduck [_ _ {:keys [database-name]} ] 
+    {:old_implicit_casting   true
+     "custom_user_agent"     "metabase_test"
+     :database_file         (format "md:%s" database-name)
+     :subname               (format "md:%s" database-name)})
+
+(doseq [[base-type db-type] {:type/BigInteger     "BIGINT"
+                             :type/Boolean        "BOOL"
+                             :type/Date           "DATE"
+                             :type/DateTime       "TIMESTAMP"
+                             :type/DateTimeWithTZ "TIMESTAMPTZ"
+                             :type/Decimal        "DECIMAL"
+                             :type/Float          "DOUBLE"
+                             :type/Integer        "INTEGER"
+                             :type/Text           "STRING"
+                             :type/Time           "TIME"
+                             :type/UUID           "UUID"}]
+  (defmethod sql.tx/field-base-type->sql-type [:motherduck base-type] [_ _] db-type))
+
+(defmethod sql.tx/pk-sql-type :motherduck [_] "INTEGER")
+
+;; (defmethod sql.tx/drop-db-if-exists-sql    :motherduck [driver {:keys [database-name]}] (format "DROP DATABASE IF EXISTS %s CASCADE" (qualify-and-quote driver database-name)))
+(defmethod sql.tx/drop-db-if-exists-sql    :motherduck [& _] nil)
+
+(defmethod ddl/drop-db-ddl-statements   :motherduck [driver {:keys [database-name]}] 
+  ["ATTACH ':memory:' AS memdb;"
+   "USE memdb;"
+   (format "DROP DATABASE %s CASCADE;" (qualify-and-quote driver database-name))])
+
+(defmethod sql.tx/create-db-sql :motherduck
+  [driver {:keys [database-name]}]
+  (format "CREATE DATABASE IF NOT EXISTS %s;" (qualify-and-quote driver database-name)))
+
+(defmethod sql.tx/add-fk-sql            :motherduck [& _] nil)
+
+(defmethod load-data/row-xform :motherduck
+  [_driver _dbdef tabledef]
+  (load-data/maybe-add-ids-xform tabledef))
+
+(defmethod tx/sorts-nil-first? :motherduck
+  [_driver _base-type]
+  false)
+
+(defmethod tx/dataset-already-loaded? :motherduck
+  [driver dbdef]
+  ;; check and make sure the first table in the dbdef has been created.
+  (let [{:keys [table-name database-name], :as _tabledef} (first (:table-definitions dbdef))]
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (md-workspace-mode-spec)
+     {:write? true}
+     (fn [^java.sql.Connection conn]
+       (try (.setAutoCommit conn true)
+            (catch Throwable _
+              (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
+       (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
+    
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :db dbdef))
+     {:write? false}
+     (fn [^java.sql.Connection conn]
+       (with-open [rset (.getTables (.getMetaData conn)
+                                    #_catalog        database-name
+                                    #_schema-pattern nil
+                                    #_table-pattern  table-name
+                                    #_types          (into-array String ["BASE TABLE"]))]
+         (.next rset))))))
+
+
+(defn- delete-old-databases!
+  "Remove all databases from motherduck account except for the default ones. Test runs can create databases that need to be cleaned up."
+  [^java.sql.Connection conn]
+  (let [drop-sql (fn [db-name] (format "DROP DATABASE IF EXISTS \"%s\" CASCADE;" db-name))]
+    (with-open [stmt (.createStatement conn)]
+      (with-open [rset (.executeQuery stmt "select database_name from duckdb_databases() where type = 'motherduck' and database_name not in ('my_db', 'sample_data'); ")]
+        (while (.next rset) 
+          (let [db-name (.getString rset "database_name")]
+            (with-open [inner-stmt (.createStatement conn)]
+              (.execute inner-stmt (drop-sql db-name)))))))))
+
+(defmethod tx/before-run :motherduck
+  [driver]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+   (md-workspace-mode-spec)
+   {:write? true}
+   delete-old-databases!))
+
+
+(defmethod tx/after-run :motherduck
+  [driver]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+   (md-workspace-mode-spec)
+   {:write? true}
+   delete-old-databases!))


### PR DESCRIPTION
We want to run the metabase driver tests against motherduck as well as local duckdb files. 
The test extension turns out to be pretty different - because of differences in the way databases get created and destroyed in local duckdb vs in motherduck. So here we create 2 versions of the test extensions. 