### PR TITLE
handle additional options in connection string

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,10 +1,10 @@
 info:
   name: Metabase DuckDB Driver
-  version: 1.0.0-SNAPSHOT-0.1.13
+  version: 1.2.1
   description: Allows Metabase to connect to DuckDB databases.
 contact-info:
-  name: Alexander Golubov
-  address: golubov.ax@yandex.ru
+  name: MotherDuck
+  address: support@motherduck.com
 driver:
   name: duckdb
   display-name: DuckDB
@@ -38,10 +38,11 @@ driver:
       type: secret
       secret-kind: password
       required: false
+    - advanced-options-start
     - merge:
         - additional-options
-        - name: additional-options
-          placeholder: ';http_keep_alive=false'
+        - display-name: Additional DuckDB connection string options
+          placeholder: 'http_keep_alive=false'
 
 init:
   - step: load-namespace

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -38,6 +38,10 @@ driver:
       type: secret
       secret-kind: password
       required: false
+    - merge:
+        - additional-options
+        - name: additional-options
+          placeholder: ';http_keep_alive=false'
 
 init:
   - step: load-namespace

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -28,8 +28,7 @@
 
 (driver/register! :duckdb, :parent :sql-jdbc)
 
-(doseq [[feature supported?] {:metadata/key-constraints      false
-                              :foreign-keys                  false
+(doseq [[feature supported?] {:metadata/key-constraints      false  ;; fetching metadata about foreign key constraints is not supported, but JOINs generally are.
                               :upload-with-auto-pk           false}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
 
@@ -64,33 +63,36 @@
               ((requiring-resolve 'metabase.models.secret/value->string)))
           ((requiring-resolve 'metabase.models.secret/get-secret-string) details-map "motherduck_token")))))
 
+
+
 (defn- jdbc-spec
   "Creates a spec for `clojure.java.jdbc` to use for connecting to DuckDB via JDBC from the given `opts`"
   [{:keys [database_file, read_only, allow_unsigned_extensions, old_implicit_casting, motherduck_token, memory_limit, azure_transport_option_type], :as details}] 
-  (-> details 
-      (merge
-       {:classname         "org.duckdb.DuckDBDriver"
-        :subprotocol       "duckdb"
-        :subname           (or database_file "")
-        "duckdb.read_only" (str read_only)
-        "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
-        "temp_directory"   (str database_file ".tmp")
-        "jdbc_stream_results" "true"
-        :TimeZone  "UTC"}
-       (when old_implicit_casting
-         {"old_implicit_casting" (str old_implicit_casting)})
-       (when memory_limit
-         {"memory_limit" (str memory_limit)})
-       (when azure_transport_option_type
-         {"azure_transport_option_type" (str azure_transport_option_type)})
-       (when allow_unsigned_extensions
-         {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
-       (when (seq (re-find #"^md:" database_file))
-         {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
-       (when (seq motherduck_token)     ;; Only configure the option if token is provided
-         {"motherduck_token" motherduck_token})) 
-      (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type)
-      sql-jdbc.common/handle-additional-options))
+  (let [database_file_base (first (str/split database_file #"\?"))] 
+    (-> details 
+        (merge
+         {:classname         "org.duckdb.DuckDBDriver"
+          :subprotocol       "duckdb"
+          :subname           (or database_file "")
+          "duckdb.read_only" (str read_only)
+          "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
+          "temp_directory"   (str database_file_base ".tmp")
+          "jdbc_stream_results" "true"
+          :TimeZone  "UTC"}
+         (when old_implicit_casting
+           {"old_implicit_casting" (str old_implicit_casting)})
+         (when memory_limit
+           {"memory_limit" (str memory_limit)})
+         (when azure_transport_option_type
+           {"azure_transport_option_type" (str azure_transport_option_type)})
+         (when allow_unsigned_extensions
+           {"allow_unsigned_extensions" (str allow_unsigned_extensions)})
+         (when (seq (re-find #"^md:" database_file))
+           {"motherduck_attach_mode"  "single"})    ;; when connecting to MotherDuck, explicitly connect to a single database
+         (when (seq motherduck_token)     ;; Only configure the option if token is provided
+           {"motherduck_token" motherduck_token})) 
+        (dissoc :database_file :read_only :port :engine :allow_unsigned_extensions :old_implicit_casting :motherduck_token :memory_limit :azure_transport_option_type)
+        sql-jdbc.common/handle-additional-options)))
 
 (defn- remove-keys-with-prefix [details prefix]
   (apply dissoc details (filter #(str/starts-with? (name %) prefix) (keys details))))
@@ -293,7 +295,13 @@
   [database_file]
   (subs database_file 3))
 
-(defn clone-raw-connection [connection]
+;; Creates a new connection to the same DuckDB instance to avoid deadlocks during concurrent operations.
+;; context: observed in tests that sometimes multiple syncs can be triggered on the same db at the same time,
+;; (and potentially the deletion of the local duckdb file) that results in bad_weak_ptr errors on the duckdb 
+;; connection object and deadlocks, so creating a lightweight clone of the connection to the same duckdb 
+;; instance to avoid deadlocks. 
+(defn- clone-raw-connection
+  [connection]
   (let [c3p0-conn (cast com.mchange.v2.c3p0.C3P0ProxyConnection connection)
         clone-method (.getMethod org.duckdb.DuckDBConnection "duplicate" (into-array Class []))
         raw-conn-token com.mchange.v2.c3p0.C3P0ProxyConnection/RAW_CONNECTION
@@ -304,13 +312,14 @@
   [driver database]
   (let
    [database_file (get (get database :details) :database_file)
+    database_file (first (str/split database_file #"\?"))  ;; remove additional options in connection string
     get_tables_query (str "select * from information_schema.tables "
                                ;; Additionally filter by db_name if connecting to MotherDuck, since
                                ;; multiple databases can be attached and information about the
                                ;; non-target database will be present in information_schema. 
                           (if (is_motherduck database_file)
-                            (let [db_name (motherduck_db_name database_file)]
-                              (format "where table_catalog = '%s' " db_name))
+                            (let [db_name_without_md (motherduck_db_name database_file)]
+                              (format "where table_catalog = '%s' " db_name_without_md))
                             ""))]
     {:tables
      (sql-jdbc.execute/do-with-connection-with-options
@@ -325,6 +334,7 @@
 (defmethod driver/describe-table :duckdb
   [driver database {table_name :name, schema :schema}]
   (let [database_file (get (get database :details) :database_file)
+        database_file (first (str/split database_file #"\?"))  ;; remove additional options in connection string
         get_columns_query (str
                            (format
                             "select * from information_schema.columns where table_name = '%s' and table_schema = '%s'"
@@ -333,8 +343,8 @@
                                   ;; multiple databases can be attached and information about the
                                   ;; non-target database will be present in information_schema. 
                            (if (is_motherduck database_file)
-                             (let [db_name (motherduck_db_name database_file)]
-                               (format "and table_catalog = '%s' " db_name))
+                             (let [db_name_without_md (motherduck_db_name database_file)]
+                               (format "and table_catalog = '%s' " db_name_without_md))
                              ""))]
     {:name   table_name
      :schema schema

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -17,8 +17,7 @@
 
 (sql-jdbc.tx/add-test-extensions! :duckdb)
 
-(doseq [[feature supported?] {:foreign-keys  (not config/is-test?)
-                              :upload-with-auto-pk (not config/is-test?)
+(doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
                               :test/time-type false
                               ::describe-table-test/describe-materialized-view-fields false
                               :test/cannot-destroy-db true}]


### PR DESCRIPTION
- additional handle connection options in connection string correctly. Currently when the db name includes config parameters, the params are treated as part of the db name in the describe databases/tables metadata query, so the query returns the wrong result. Correct this by removing the param string in the query. 
- add the additional options field as a different way to set duckdb/motherduck configs. 
