### PR TITLE
upload artifact before integration tests, which could fail

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -51,16 +51,16 @@ jobs:
         chmod +x ./bin/build-driver.sh
         ./bin/build-driver.sh duckdb
         
-    - name: Run integration tests
-      working-directory: ./metabase
-      run: |
-        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
-        MB_EDITION=ee yarn build-static-viz
-        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
-        
     - name: Upload driver artifact
       uses: actions/upload-artifact@v4
       with:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
+       
+    - name: Run integration tests
+      working-directory: ./metabase
+      run: |
+        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
+        MB_EDITION=ee yarn build-static-viz
+        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test


### PR DESCRIPTION
there's a small number of known failing tests, for now don't block the publishing of artifacts on them. 