### PR TITLE
merge main branch changes into metabase cloud branch

### DIFF
--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -23,11 +23,11 @@ jobs:
       with:
         path: metabase/modules/drivers/duckdb
         
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '21'
         
     - name: Set up Node.js
       uses: actions/setup-node@v4
@@ -57,3 +57,20 @@ jobs:
         name: metabase-duckdb-driver
         path: metabase/resources/modules/duckdb.metabase-driver.jar
         if-no-files-found: error
+        
+    - name: Run integration tests against MotherDuck
+      working-directory: ./metabase
+      continue-on-error: true
+      env:
+          motherduck_token: ${{ secrets.motherduck_ci_user_token }}
+      run: |
+        git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
+        MB_EDITION=ee yarn build-static-viz
+        DRIVERS=motherduck clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+       
+    - name: Run integration tests against DuckDB local
+      working-directory: ./metabase
+      continue-on-error: true
+      run: |
+        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
+

--- a/.github/workflows/build_metabase_duckdb_driver.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver.yaml
@@ -67,10 +67,3 @@ jobs:
         git apply ./modules/drivers/duckdb/ci/metabase_test_deps.patch
         MB_EDITION=ee yarn build-static-viz
         DRIVERS=motherduck clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
-       
-    - name: Run integration tests against DuckDB local
-      working-directory: ./metabase
-      continue-on-error: true
-      run: |
-        DRIVERS=duckdb clojure -X:dev:drivers:drivers-dev:ee:ee-dev:test
-

--- a/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
+++ b/.github/workflows/build_metabase_duckdb_driver_musllinux.yaml
@@ -69,11 +69,11 @@ jobs:
       with:
         path: metabase/modules/drivers/duckdb
 
-    - name: Set up JDK 11
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '21'
 
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4.5

--- a/ci/metabase_drivers_deps.patch
+++ b/ci/metabase_drivers_deps.patch
@@ -1,11 +1,11 @@
 diff --git a/modules/drivers/deps.edn b/modules/drivers/deps.edn
-index 0868e24de0..8d6c76a8ef 100644
+index 98f65a210d..e0c8da9d68 100644
 --- a/modules/drivers/deps.edn
 +++ b/modules/drivers/deps.edn
-@@ -21,4 +21,6 @@
-   metabase/sparksql           {:local/root "sparksql"}
+@@ -23,4 +23,6 @@
    metabase/sqlite             {:local/root "sqlite"}
    metabase/sqlserver          {:local/root "sqlserver"}
+   metabase/starburst          {:local/root "starburst"}
 -  metabase/vertica            {:local/root "vertica"}}}
 +  metabase/vertica            {:local/root "vertica"}
 +  metabase/duckdb             {:local/root "duckdb"}

--- a/ci/metabase_test_deps.patch
+++ b/ci/metabase_test_deps.patch
@@ -1,0 +1,15 @@
+diff --git a/deps.edn b/deps.edn
+index 67e3128c77..c656572f23 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -430,7 +430,9 @@
+     "modules/drivers/sqlite/test"
+     "modules/drivers/sqlserver/test"
+     "modules/drivers/starburst/test"
+-    "modules/drivers/vertica/test"]}
++    "modules/drivers/vertica/test"
++    "modules/drivers/duckdb/test"
++    ]}
+ 
+ ;;; Linters
+ 

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.duckdb/duckdb_jdbc {:mvn/version "1.2.0"}}}
+ {org.duckdb/duckdb_jdbc {:mvn/version "1.2.2.0"}}}

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase DuckDB Driver
-  version: 1.2.0
+  version: 1.2.2.0
   description: Allows Metabase to connect to DuckDB databases.
 contact-info:
   name: MotherDuck Support
@@ -24,6 +24,11 @@ driver:
       type: secret
       secret-kind: password
       required: true
+    - advanced-options-start
+    - merge:
+        - additional-options
+        - display-name: Additional DuckDB connection string options
+          placeholder: 'http_keep_alive=false'
 
 init:
   - step: load-namespace

--- a/src/metabase/driver/motherduck.clj
+++ b/src/metabase/driver/motherduck.clj
@@ -1,0 +1,6 @@
+(ns metabase.driver.motherduck 
+  (:require    
+   [metabase.driver :as driver]))
+
+
+(driver/register! :motherduck, :parent :duckdb)

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -1,34 +1,37 @@
 (ns metabase.test.data.duckdb
   (:require
-   [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.string :as str]
    [metabase.config :as config]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
-   [metabase.test.data.sql-jdbc.execute :as execute]
    [metabase.test.data.sql-jdbc.load-data :as load-data]
-   [metabase.test.data.sql.ddl :as ddl]
-   [metabase.util :as u]
-   [metabase.util.log :as log]))
+
+   [metabase.test.data.sql.ddl :as ddl]))
 
 (set! *warn-on-reflection* true)
 
 (sql-jdbc.tx/add-test-extensions! :duckdb)
 
-(doseq [[feature supported?] {:foreign-keys  (not config/is-test?) 
-                              :upload-with-auto-pk (not config/is-test?)}]
+(doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
+                              :test/time-type false
+                              ::describe-table-test/describe-materialized-view-fields false  ;; duckdb has no materialized views
+                              :test/cannot-destroy-db true}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
 
-(defmethod tx/supports-time-type? :duckdb [_driver] false)
+(defmethod tx/bad-connection-details :duckdb
+  [_driver]
+  {:unknown_config "single"})
 
-(defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}] 
+(defmethod tx/dbdef->connection-details :duckdb [_ _ {:keys [database-name]}]
   {:old_implicit_casting   true
    "temp_directory"        (format "%s.ddb.tmp" database-name)
    :database_file (format "%s.ddb" database-name)
-   "custom_user_agent"     "metabase_test" 
+   "custom_user_agent"     "metabase_test"
    :subname                (format "%s.ddb" database-name)})
 
 (doseq [[base-type db-type] {:type/BigInteger     "BIGINT"
@@ -37,13 +40,12 @@
                              :type/DateTime       "TIMESTAMP"
                              :type/DateTimeWithTZ "TIMESTAMPTZ"
                              :type/Decimal        "DECIMAL"
-                             :type/Float          "FLOAT"
+                             :type/Float          "DOUBLE"
                              :type/Integer        "INTEGER"
                              :type/Text           "STRING"
                              :type/Time           "TIME"
                              :type/UUID           "UUID"}]
   (defmethod sql.tx/field-base-type->sql-type [:duckdb base-type] [_ _] db-type))
-
 
 (defmethod sql.tx/pk-sql-type :duckdb [_] "INTEGER")
 
@@ -60,48 +62,29 @@
     (when (.exists wal-file)
       (.delete wal-file))))
 
-
 (defmethod sql.tx/add-fk-sql            :duckdb [& _] nil)
 
-(defmethod load-data/load-data! :duckdb [& args]
-  (apply load-data/load-data-maybe-add-ids-chunked! args))
-
-(defonce ^:private reference-load-durations
-  (delay (edn/read-string (slurp "test_resources/load-durations.edn"))))
-
+(defmethod load-data/row-xform :duckdb
+  [_driver _dbdef tabledef]
+  (load-data/maybe-add-ids-xform tabledef))
 
 (defmethod tx/sorts-nil-first? :duckdb
   [_driver _base-type]
   false)
 
-(defmethod tx/create-db! :duckdb
-  [driver {:keys [table-definitions] :as dbdef} & options] 
-  (try 
-    (doseq [statement (apply ddl/drop-db-ddl-statements driver dbdef options)]
-      (execute/execute-sql! driver :server dbdef statement))
-    (catch Throwable e
-      (log/infof "Error dropping DB: %s" (ex-message e))))
-  
-  (tx/destroy-db! driver dbdef)
-  ;; now execute statements to create the DB
-  (doseq [statement (ddl/create-db-ddl-statements driver dbdef)]
-    (execute/execute-sql! driver :server dbdef statement))
-  ;; next, get a set of statements for creating the tables
-  (let [statements (apply ddl/create-db-tables-ddl-statements driver dbdef options)]
-    ;; exec the combined statement. Notice we're now executing in the `:db` context e.g. executing them for a specific
-    ;; DB rather than on `:server` (no DB in particular)
-    (execute/execute-sql! driver :db dbdef (str/join ";\n" statements)))
-  ;; Now load the data for each Table
-  (doseq [tabledef table-definitions
-          :let     [reference-duration (or (some-> (get @reference-load-durations [(:database-name dbdef) (:table-name tabledef)])
-                                                   u/format-nanoseconds)
-                                           "NONE")]]
-    (u/profile (format "load-data for %s %s %s (reference H2 duration: %s)"
-                       (name driver) (:database-name dbdef) (:table-name tabledef) reference-duration)
-               (try
-                 (load-data/load-data! driver dbdef tabledef)
-                 (catch Throwable e
-                   (throw (ex-info (format "Error loading data: %s" (ex-message e))
-                                   {:driver driver, :tabledef (update tabledef :rows (fn [rows]
-                                                                                       (concat (take 10 rows) ['...])))}
-                                   e)))))))
+(defmethod tx/dataset-already-loaded? :duckdb
+  [driver dbdef]
+  ;; check and make sure the first table in the dbdef has been created.
+  (let [{:keys [table-name], :as _tabledef} (first (:table-definitions dbdef))]
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :db dbdef))
+     {:write? false}
+     (fn [^java.sql.Connection conn]
+       (with-open [rset (.getTables (.getMetaData conn)
+                                    #_catalog        nil
+                                    #_schema-pattern nil
+                                    #_table-pattern  table-name
+                                    #_types          (into-array String ["BASE TABLE"]))]
+         ;; if the ResultSet returns anything we know the table is already loaded.
+         (.next rset))))))

--- a/test/metabase/test/data/duckdb.clj
+++ b/test/metabase/test/data/duckdb.clj
@@ -19,7 +19,8 @@
 
 (doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
                               :test/time-type false
-                              ::describe-table-test/describe-materialized-view-fields false  ;; duckdb has no materialized views
+                              ::describe-table-test/describe-materialized-view-fields false  ;
+                              :metabase.query-processor-test.date-bucketing-test/group-by-week-database-timezone-override-test false; duckdb has no materialized views
                               :test/cannot-destroy-db true}]
   (defmethod driver/database-supports? [:duckdb feature] [_driver _feature _db] supported?))
 

--- a/test/metabase/test/data/motherduck.clj
+++ b/test/metabase/test/data/motherduck.clj
@@ -1,0 +1,145 @@
+(ns metabase.test.data.motherduck
+  (:require
+   [clojure.tools.logging :as log]
+   [metabase.config :as config]
+   [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync.describe-table-test :as describe-table-test]
+   [metabase.test.data.interface :as tx]
+   [metabase.test.data.sql :as sql.tx :refer [qualify-and-quote]]
+   [metabase.test.data.sql-jdbc.execute :as sql-jdbc.test-execute]
+   [metabase.test.data.sql-jdbc.load-data :as load-data]
+   [metabase.test.data.sql-jdbc.spec  :refer [dbdef->spec]]
+   [metabase.test.data.sql.ddl :as ddl]))
+
+(set! *warn-on-reflection* true)
+
+(doseq [[feature supported?] {:upload-with-auto-pk (not config/is-test?)
+                              :test/time-type false
+                              ::describe-table-test/describe-materialized-view-fields false  ;; motherduck has no materialized views
+                              :test/cannot-destroy-db true}]
+  (defmethod driver/database-supports? [:motherduck feature] [_driver _feature _db] supported?))
+
+(defmethod tx/bad-connection-details :motherduck
+  [_driver]
+  {:unknown_config "single"})
+
+(defmethod dbdef->spec :motherduck [driver context dbdef]
+  (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver context dbdef)))
+
+;; use this to connect to MotherDuck in workspace mode, to set up and destroy test databases.
+(defn- md-workspace-mode-spec 
+  []
+  (sql-jdbc.conn/connection-details->spec :motherduck {:old_implicit_casting   true
+                                                  "custom_user_agent"     "metabase_test"
+                                                  :database_file          "md:"
+                                                  :subname                "md:"
+                                                  :attach_mode            "workspace"}))
+
+(defmethod tx/create-db! :motherduck
+  [driver dbdef & options] 
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver 
+   (md-workspace-mode-spec)
+   {:write? true}
+   (fn [^java.sql.Connection conn]
+     (try (.setAutoCommit conn true)
+          (catch Throwable _
+            (log/debugf "`.setAutoCommit` failed with engine `%s`" (name driver))))
+     (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
+
+  (apply load-data/create-db! driver dbdef options))
+
+
+  (defmethod tx/dbdef->connection-details :motherduck [_ _ {:keys [database-name]} ] 
+    {:old_implicit_casting   true
+     "custom_user_agent"     "metabase_test"
+     :database_file         (format "md:%s" database-name)
+     :subname               (format "md:%s" database-name)})
+
+(doseq [[base-type db-type] {:type/BigInteger     "BIGINT"
+                             :type/Boolean        "BOOL"
+                             :type/Date           "DATE"
+                             :type/DateTime       "TIMESTAMP"
+                             :type/DateTimeWithTZ "TIMESTAMPTZ"
+                             :type/Decimal        "DECIMAL"
+                             :type/Float          "DOUBLE"
+                             :type/Integer        "INTEGER"
+                             :type/Text           "STRING"
+                             :type/Time           "TIME"
+                             :type/UUID           "UUID"}]
+  (defmethod sql.tx/field-base-type->sql-type [:motherduck base-type] [_ _] db-type))
+
+(defmethod sql.tx/pk-sql-type :motherduck [_] "INTEGER")
+
+(defmethod ddl/drop-db-ddl-statements   :motherduck [driver {:keys [database-name]}] 
+  ["ATTACH IF NOT EXISTS ':memory:' AS memdb;"
+   "USE memdb;"
+   (format "DROP DATABASE %s CASCADE;" (qualify-and-quote driver database-name))])
+
+(defmethod sql.tx/create-db-sql :motherduck
+  [driver {:keys [database-name]}]
+  (format "CREATE DATABASE IF NOT EXISTS %s;" (qualify-and-quote driver database-name)))
+
+(defmethod sql.tx/add-fk-sql            :motherduck [& _] nil)
+
+(defmethod load-data/row-xform :motherduck
+  [_driver _dbdef tabledef]
+  (load-data/maybe-add-ids-xform tabledef))
+
+(defmethod tx/sorts-nil-first? :motherduck
+  [_driver _base-type]
+  false)
+
+(defmethod tx/dataset-already-loaded? :motherduck
+  [driver dbdef]
+  ;; check and make sure the first table in the dbdef has been created.
+  (let [{:keys [table-name database-name], :as _tabledef} (first (:table-definitions dbdef))]
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (md-workspace-mode-spec)
+     {:write? true}
+     (fn [^java.sql.Connection conn]
+       (sql-jdbc.test-execute/execute-sql! driver conn (sql.tx/create-db-sql driver dbdef))))
+    
+    (sql-jdbc.execute/do-with-connection-with-options
+     driver
+     (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :db dbdef))
+     {:write? false}
+     (fn [^java.sql.Connection conn]
+       (with-open [rset (.getTables (.getMetaData conn)
+                                    #_catalog        database-name
+                                    #_schema-pattern nil
+                                    #_table-pattern  table-name
+                                    #_types          (into-array String ["BASE TABLE"]))]
+         (.next rset))))))
+
+
+(defn- delete-old-databases!
+  "Remove all databases from motherduck account except for the default ones. Test runs can create databases that need to be cleaned up."
+  [^java.sql.Connection conn]
+  (let [drop-sql (fn [db-name] (format "DROP DATABASE IF EXISTS \"%s\" CASCADE;" db-name))]
+    (with-open [stmt (.createStatement conn)]
+      (with-open [rset (.executeQuery stmt "select database_name from duckdb_databases() where type = 'motherduck' and database_name not in ('my_db', 'sample_data'); ")]
+        (while (.next rset) 
+          (let [db-name (.getString rset "database_name")]
+            (with-open [inner-stmt (.createStatement conn)]
+              (.execute inner-stmt (drop-sql db-name)))))))))
+
+(defmethod tx/before-run :motherduck
+  [driver]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+   (md-workspace-mode-spec)
+   {:write? true}
+   delete-old-databases!))
+
+
+(defmethod tx/after-run :motherduck
+  [driver]
+  (sql-jdbc.execute/do-with-connection-with-options
+   driver
+   (md-workspace-mode-spec)
+   {:write? true}
+   delete-old-databases!))


### PR DESCRIPTION
In Metabase Cloud, the driver needs to enforce saas_mode to ensure there's no local file access and also to prevent query execution from happening locally. 
unfortunately, in saas_mode, the duckdb icu extension cannot be loaded locally (as there's no local file access after connection is established), and so the timezone config cannot be set or changed, so the server will always be in the default timezone which is UTC, and the client will always be in the machine's timezone. We disable timezone settings in the test extensions and the driver to fix test failures from this change.