### PR TITLE
Set DuckDB's TimeZone after connecting, not as a startup property

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -204,14 +204,17 @@
          (ensure-init-sql! conn init-sql)))
      ;; Set the timezone here rather than as a connection property: TimeZone comes from the
      ;; icu extension, and passing it at startup makes the whole connection fail when icu
-     ;; cannot be autoloaded (air-gapped installs). Here a failure only costs us UTC.
+     ;; cannot be autoloaded (air-gapped installs). Failing here costs only the setting --
+     ;; but the session then runs in the JVM's zone, which silently shifts timestamps with
+     ;; a time zone, so say so. Without icu there is no way to pin the zone at all.
      (when (not (sql-jdbc.execute/recursive-connection?))
        (let [timezone-to-use (or report-timezone session-timezone "UTC")]
          (try
            (with-open [stmt (.createStatement conn)]
              (.execute stmt (format "SET TimeZone='%s';" timezone-to-use)))
            (catch Throwable e
-             (log/debugf e "Error setting timezone '%s' for DuckDB database" timezone-to-use)))))
+             (log/warnf e "Could not set DuckDB TimeZone to '%s'; this connection will use the server timezone instead"
+                        timezone-to-use)))))
      ;; Call the function with the configured connection
      (f conn))))
 

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -153,8 +153,7 @@
           :subname           (or database_file "")
           "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
           "temp_directory"   (str database_file_base ".tmp")
-          "jdbc_stream_results" "true"
-          :TimeZone  "UTC"}
+          "jdbc_stream_results" "true"}
          (when (some? read_only)
            {"duckdb.read_only" (str read_only)})
          (when old_implicit_casting
@@ -203,9 +202,11 @@
      (when (not (sql-jdbc.execute/recursive-connection?))
        (when-let [init-sql (-> db-or-id-or-spec :details :init_sql)]
          (ensure-init-sql! conn init-sql)))
-     ;; Additionally set timezone if provided and we're not in a recursive connection
-     (when (and (or report-timezone session-timezone) (not (sql-jdbc.execute/recursive-connection?)))
-       (let [timezone-to-use (or report-timezone session-timezone)]
+     ;; Set the timezone here rather than as a connection property: TimeZone comes from the
+     ;; icu extension, and passing it at startup makes the whole connection fail when icu
+     ;; cannot be autoloaded (air-gapped installs). Here a failure only costs us UTC.
+     (when (not (sql-jdbc.execute/recursive-connection?))
+       (let [timezone-to-use (or report-timezone session-timezone "UTC")]
          (try
            (with-open [stmt (.createStatement conn)]
              (.execute stmt (format "SET TimeZone='%s';" timezone-to-use)))

--- a/test/metabase/driver/duckdb_test.clj
+++ b/test/metabase/driver/duckdb_test.clj
@@ -1,0 +1,13 @@
+(ns metabase.driver.duckdb-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver.duckdb]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]))
+
+(comment metabase.driver.duckdb/keep-me)
+
+(deftest connection-spec-omits-timezone-test
+  (testing "TimeZone is not a startup property: it comes from the icu extension, which cannot
+           be autoloaded on air-gapped installs, and there it fails the whole connection"
+    (let [spec (sql-jdbc.conn/connection-details->spec :duckdb {:database_file ":memory:"})]
+      (is (not-any? #{:TimeZone "TimeZone"} (keys spec))))))


### PR DESCRIPTION
TimeZone comes from the icu extension. Passing it in the JDBC properties makes DuckDB resolve icu during connection startup, and where the extension repository is unreachable (air-gapped installs) that fails:

```
Invalid Input Error: To set the TimeZone setting, the icu extension needs to be loaded. But it could not be autoloaded.
```

Reproduced with the shipped 1.5.5.0 jar and no network: every connection fails, whatever the user's timezone, because the driver always sent TimeZone=UTC. Setting it after connecting instead reuses the existing try/catch, so icu trouble now costs a debug line rather than the database. Default stays UTC and report-timezone still wins.

Should solve some issues in https://github.com/motherduckdb/metabase_duckdb_driver/issues/60