### PR TITLE
Safeguards around temp_directory for URL-style paths

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.duckdb
   (:require
+   [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -127,6 +128,22 @@
         [database-file additional-options])
       [database_file ""])))
 
+(defn- temp-directory
+  "Directory DuckDB may spill to. `<database file>.tmp` is only a usable directory for plain
+   file paths: for URL-style paths (`md:`, `ducklake:`, ...) and `:memory:` both this and
+   DuckDB's own default produce a bogus path, so spilling queries fail with
+   `Failed to create directory \"ducklake:...\"`. Those get a per-database directory under
+   `java.io.tmpdir` instead. A single leading letter (`C:\\...`) is a Windows drive, not a scheme."
+  [database_file_base]
+  (if (and (seq database_file_base)
+           (not (str/starts-with? database_file_base ":memory:"))
+           (not (re-find #"^[A-Za-z][A-Za-z0-9+.-]+:" database_file_base)))
+    (str database_file_base ".tmp")
+    (let [slug (str/replace database_file_base #"[^A-Za-z0-9._-]" "_")
+          slug (subs slug 0 (min 40 (count slug)))]
+      (str (io/file (System/getProperty "java.io.tmpdir")
+                    (format "metabase-duckdb-%s-%08x.tmp" slug (hash database_file_base)))))))
+
 (defn- remove-internal-connection-keys
   "Metabase annotates effective connection details with internal keys that should
    not be forwarded to DuckDB as JDBC properties."
@@ -152,7 +169,7 @@
           :subprotocol       "duckdb"
           :subname           (or database_file "")
           "custom_user_agent" (str "metabase" (if (is-hosted?) " metabase-cloud" ""))
-          "temp_directory"   (str database_file_base ".tmp")
+          "temp_directory"   (temp-directory database_file_base)
           "jdbc_stream_results" "true"
           :TimeZone  "UTC"}
          (when (some? read_only)

--- a/test/metabase/driver/duckdb_test.clj
+++ b/test/metabase/driver/duckdb_test.clj
@@ -1,0 +1,31 @@
+(ns metabase.driver.duckdb-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.driver.duckdb]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]))
+
+(comment metabase.driver.duckdb/keep-me)
+
+(defn- temp-dir-for [database-file]
+  (get (sql-jdbc.conn/connection-details->spec :duckdb {:database_file database-file})
+       "temp_directory"))
+
+(deftest temp-directory-test
+  (testing "a plain database file spills next to itself"
+    (is (= "/data/warehouse.db.tmp" (temp-dir-for "/data/warehouse.db")))
+    (is (= "warehouse.db.tmp" (temp-dir-for "warehouse.db"))))
+  (testing "query parameters are not part of the temp directory"
+    (is (= "/data/warehouse.db.tmp" (temp-dir-for "/data/warehouse.db?read_only=true"))))
+  (testing "URL-style paths and :memory: spill under java.io.tmpdir, never a path with a scheme"
+    (let [tmpdir (System/getProperty "java.io.tmpdir")]
+      (doseq [database-file ["ducklake:/lake/catalog.ducklake"
+                             "ducklake:sqlite:/warehouse/meta.db"
+                             "md:my_database"
+                             "md:my_database?motherduck_token=x"
+                             ":memory:"]]
+        (let [temp-dir (temp-dir-for database-file)]
+          (is (str/starts-with? temp-dir tmpdir) database-file)
+          (is (not (str/includes? (subs temp-dir (count tmpdir)) ":")) database-file)))))
+  (testing "different databases never share a spill directory"
+    (is (not= (temp-dir-for "md:db_one") (temp-dir-for "md:db_two")))))


### PR DESCRIPTION
During an agent driven repro spree Claude was insisting on covering the following edge-case it found and I confirmed looking at the implementation:

The `temp_directory` was always `<database file>.tmp` which breaks for URL-style databases like  `ducklake:/lake/cat.ducklake`: "IO Error: Failed to create directory "ducklake:/lake/cat.ducklake.tmp". Whenever we recognise that we're not talking to an actual DuckDB file on disk and hence don't know if we can write there, we now create a per-database directory under `java.io.tmpdir` instead, which seems to be [the JVM-way](https://system-properties.com/java.io.tmpdir/).