### PR TITLE
Recycle live connection pools when validating changed details

### DIFF
--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -38,6 +38,7 @@ driver:
       type: secret
       secret-kind: password
       required: false
+      helper-text: Saving a changed token closes this database's current connections; queries still running at that moment may fail and can simply be retried.
     - name: init_sql
       display-name: Init SQL (run on each new DuckDB instance)
       type: text

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -189,6 +189,53 @@
       (remove-keys-with-prefix "motherduck_token-")
       jdbc-spec))
 
+(defn- same-file-different-config-error?
+  "DuckDB allows one instance per database file per process: opening the same file with
+   changed settings (e.g. a rotated MotherDuck token) is refused while the old instance
+   has open connections."
+  [^Throwable e]
+  (boolean (some #(some-> (ex-message %) (str/includes? "with a different configuration"))
+                 (take-while some? (iterate #(.getCause ^Throwable %) e)))))
+
+(defn- database-ids-with-file
+  "Ids of saved DuckDB databases whose details point at `database-file`."
+  [database-file]
+  (let [select (requiring-resolve 'toucan2.core/select)]
+    (for [db (select :model/Database :engine "duckdb")
+          :when (= database-file (get-in db [:details :database_file]))]
+      (:id db))))
+
+(defmethod driver/can-connect? :duckdb
+  [driver details]
+  (try
+    (sql-jdbc.conn/can-connect? driver details)
+    (catch Throwable e
+      (let [db-ids (when (same-file-different-config-error? e)
+                     (seq (database-ids-with-file (:database_file details))))]
+        (when-not db-ids
+          (throw e))
+        ;; The user is saving changed details (e.g. a rotated token) for a database this
+        ;; process already holds open. Validation runs before the save, so without
+        ;; recycling the old pools here the new details could never be validated, let
+        ;; alone saved.
+        (log/warnf "Recycling connection pool(s) of database(s) %s to validate changed connection details; queries running at this moment will be interrupted"
+                   (str/join ", " db-ids))
+        (doseq [id db-ids]
+          (sql-jdbc.conn/invalidate-pool-for-db! id))
+        ;; c3p0 closes the evicted connections on helper threads, so the old instance can
+        ;; outlive invalidate-pool-for-db! by a moment; keep retrying while it does.
+        (loop [attempts-left 20]
+          (let [result (try
+                         (sql-jdbc.conn/can-connect? driver details)
+                         (catch Throwable retry-e
+                           (when-not (and (pos? attempts-left) (same-file-different-config-error? retry-e))
+                             (throw retry-e))
+                           ::old-instance-still-open))]
+            (if (= result ::old-instance-still-open)
+              (do (Thread/sleep 250)
+                  (recur (dec attempts-left)))
+              result)))))))
+
 (defmethod sql-jdbc.execute/do-with-connection-with-options :duckdb
   [driver db-or-id-or-spec {:keys [^String session-timezone report-timezone] :as options} f]
   ;; First use the parent implementation to get the connection with standard options

--- a/test/metabase/driver/duckdb_test.clj
+++ b/test/metabase/driver/duckdb_test.clj
@@ -1,0 +1,25 @@
+(ns metabase.driver.duckdb-test
+  (:require
+   [clojure.java.jdbc :as jdbc]
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.driver.duckdb]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.test :as mt]))
+
+(comment metabase.driver.duckdb/keep-me)
+
+(deftest can-connect-recycles-conflicting-pool-test
+  (testing "validating changed details recycles the live pool instead of failing (token rotation flow):
+           DuckDB refuses to open the same file with a different configuration while the old
+           instance has open connections, which used to fail validation and so block the save"
+    (let [file (str (System/getProperty "java.io.tmpdir") "/pool-recycle-" (System/currentTimeMillis) ".db")]
+      (mt/with-temp [:model/Database db {:engine :duckdb, :details {:database_file file}}]
+        (try
+          ;; open a pooled connection the way a running Metabase holds one
+          (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec db) ["SELECT 1"])
+          ;; same file, different config: without recycling this throws
+          ;; "Can't open a connection to same database file with a different configuration"
+          (is (true? (driver/can-connect? :duckdb {:database_file file, :read_only true})))
+          (finally
+            (sql-jdbc.conn/invalidate-pool-for-db! db)))))))


### PR DESCRIPTION
DuckDB allows one instance per database file per process, so while the pool holds connections changing the MotherDuck token fails with "Can't open a connection to same database file with a different configuration". Metabase validates before saving, so the new token could never be stored and the old one kept serving queries until a restart:

<img width="720" height="257" alt="image" src="https://github.com/user-attachments/assets/fee3bdd0-3fe9-44aa-8bb3-f9ac932d0d76" />

Change: `can-connect?` now invalidates its pools so the old instance closes. Also a helper text on the token field now warns that saving a changed token can interrupt queries running at that moment.