### PR TITLE
Map nested and exotic DuckDB types to the right metabase types

### DIFF
--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -219,7 +219,12 @@
 
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
-   [[#"BOOLEAN"                  :type/Boolean]
+   ;; First match wins. Nested types arrive as their full definition, e.g. STRUCT(started_at TIMESTAMP), so they must
+   ;; be matched before the scalar patterns, which would otherwise pick up a field or element type from inside them.
+   [[#"\[\d*\]$"                 :type/Array]
+    [#"^(?:STRUCT|MAP)\("        :type/Dictionary]
+    [#"^UNION\("                 :type/*]
+    [#"BOOLEAN"                  :type/Boolean]
     [#"BOOL"                     :type/Boolean]
     [#"LOGICAL"                  :type/Boolean]
     [#"HUGEINT"                  :type/BigInteger]
@@ -270,14 +275,7 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :duckdb
   [_ field-type]
-  (let [type-name (name field-type)]
-    (cond
-      ;; Nested types arrive as their full definition, e.g. STRUCT(started_at TIMESTAMP). Matched by substring against
-      ;; the scalar patterns above they would take the type of whichever field or element they happen to contain.
-      (re-find #"\[\d*\]$" type-name)        :type/Array
-      (re-find #"^(STRUCT|MAP)\(" type-name) :type/Dictionary
-      (re-find #"^UNION\(" type-name)        :type/*
-      :else                                  (database-type->base-type field-type))))
+  (database-type->base-type field-type))
 
 (defn- local-time-to-time [^LocalTime lt]
   (Time. (.getLong lt ChronoField/MILLI_OF_DAY)))

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -219,11 +219,16 @@
 
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
-   ;; First match wins. Nested types arrive as their full definition, e.g. STRUCT(started_at TIMESTAMP), so they must
-   ;; be matched before the scalar patterns, which would otherwise pick up a field or element type from inside them.
+   ;; First match wins. Nested types arrive as their full definition, e.g. STRUCT(started_at TIMESTAMP), so they and
+   ;; the names that merely contain a scalar type name (INTERVAL, POINT_2D) go before the substring-matched scalars.
    [[#"\[\d*\]$"                 :type/Array]
     [#"^(?:STRUCT|MAP)\("        :type/Dictionary]
     [#"^UNION\("                 :type/*]
+    [#"^ENUM\("                  :type/Text]
+    [#"^INTERVAL$"               :type/*]
+    [#"^BIGNUM$"                 :type/BigInteger]
+    [#"_2D$"                     :type/*]          ; spatial extension: POINT_2D, LINESTRING_2D, POLYGON_2D, BOX_2D
+    [#"^TIME WITH TIME ZONE$"    :type/TimeWithTZ]
     [#"BOOLEAN"                  :type/Boolean]
     [#"BOOL"                     :type/Boolean]
     [#"LOGICAL"                  :type/Boolean]

--- a/src/metabase/driver/duckdb.clj
+++ b/src/metabase/driver/duckdb.clj
@@ -270,7 +270,14 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :duckdb
   [_ field-type]
-  (database-type->base-type field-type))
+  (let [type-name (name field-type)]
+    (cond
+      ;; Nested types arrive as their full definition, e.g. STRUCT(started_at TIMESTAMP). Matched by substring against
+      ;; the scalar patterns above they would take the type of whichever field or element they happen to contain.
+      (re-find #"\[\d*\]$" type-name)        :type/Array
+      (re-find #"^(STRUCT|MAP)\(" type-name) :type/Dictionary
+      (re-find #"^UNION\(" type-name)        :type/*
+      :else                                  (database-type->base-type field-type))))
 
 (defn- local-time-to-time [^LocalTime lt]
   (Time. (.getLong lt ChronoField/MILLI_OF_DAY)))

--- a/test/metabase/driver/duckdb_test.clj
+++ b/test/metabase/driver/duckdb_test.clj
@@ -1,0 +1,22 @@
+(ns metabase.driver.duckdb-test
+  (:require
+   [clojure.test :refer [are deftest testing]]
+   [metabase.driver.duckdb]
+   [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]))
+
+(deftest ^:parallel database-type->base-type-test
+  (testing "nested types are typed as a whole, not by the scalar type names inside them"
+    (are [database-type base-type] (= base-type (sql-jdbc.sync/database-type->base-type :duckdb database-type))
+      "STRUCT(started_at TIMESTAMP, ended_at TIMESTAMP)" :type/Dictionary
+      "STRUCT(plan VARCHAR, seats INTEGER)"              :type/Dictionary
+      "MAP(VARCHAR, INTEGER)"                            :type/Dictionary
+      "INTEGER[]"                                        :type/Array
+      "INTEGER[3]"                                       :type/Array
+      "STRUCT(a DATE)[]"                                 :type/Array
+      "UNION(num INTEGER, str VARCHAR)"                  :type/*))
+  (testing "scalar types keep their mapping"
+    (are [database-type base-type] (= base-type (sql-jdbc.sync/database-type->base-type :duckdb database-type))
+      "INTEGER"                  :type/Integer
+      "DECIMAL(18,3)"            :type/Decimal
+      "TIMESTAMP WITH TIME ZONE" :type/DateTimeWithTZ
+      "VARCHAR"                  :type/Text)))

--- a/test/metabase/driver/duckdb_test.clj
+++ b/test/metabase/driver/duckdb_test.clj
@@ -14,6 +14,14 @@
       "INTEGER[3]"                                       :type/Array
       "STRUCT(a DATE)[]"                                 :type/Array
       "UNION(num INTEGER, str VARCHAR)"                  :type/*))
+  (testing "names that contain a scalar type name, or had no pattern, are mapped explicitly"
+    (are [database-type base-type] (= base-type (sql-jdbc.sync/database-type->base-type :duckdb database-type))
+      "INTERVAL"                      :type/*
+      "ENUM('sad', 'ok', 'INTERNAL')" :type/Text
+      "BIGNUM"                        :type/BigInteger
+      "POINT_2D"                      :type/*
+      "LINESTRING_2D"                 :type/*
+      "TIME WITH TIME ZONE"           :type/TimeWithTZ))
   (testing "scalar types keep their mapping"
     (are [database-type base-type] (= base-type (sql-jdbc.sync/database-type->base-type :duckdb database-type))
       "INTEGER"                  :type/Integer


### PR DESCRIPTION
For non-scalar types in particular, the base-type patterns are matched by substring, so a column typed `STRUCT(started_at TIMESTAMP, ...)` turned into a DateTime and `STRUCT(plan VARCHAR, seats INTEGER)`, `INTEGER[]` and `MAP(VARCHAR, INTEGER)` into integers. Metabase then fingerprinted and grouped them as such, e.g. a distribution on the struct failed with date_trunc(..., STRUCT). This should result in better support for struct types. Other types fixed here are geometry types, interval, and enums.